### PR TITLE
Fix gamertag getters and MGC version.

### DIFF
--- a/source/GDKExtension_gml/datafiles/MicrosoftGame.Config
+++ b/source/GDKExtension_gml/datafiles/MicrosoftGame.Config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Game configVersion="0">
+<Game configVersion="1">
   <!-- For more information on MicrosoftGame.config elements,
        please refer to online GDK documentation found at https://aka.ms/GDK_MSGC
        or the MicrosoftGame.config topic in the System section of the offline GDK documentation. -->
@@ -8,6 +8,7 @@
   <StoreId>9N4HJ1SPR17N</StoreId>
   <TitleId>790907E2</TitleId>
   <MSAAppId>000000004C3D5752</MSAAppId>
+  <AdvancedUserModel>false</AdvancedUserModel>
   <ExecutableList>
     <Executable Name="GDKExtension.exe" Id="Game" />
     <!--    TargetDeviceFamily="PC"
@@ -41,7 +42,6 @@
     <ExtendedAttribute Name="Scid" Value="00000000-0000-0000-0000-0000790907e2" />
   </ExtendedAttributeList>
   <DevelopmentOnly>
-    <ContentIdOverride>3EA05A8A-CF24-4938-A6D8-389540AEB2E4</ContentIdOverride>
   </DevelopmentOnly>
   <DesktopRegistration>
     <DependencyList>

--- a/source/GDKExtension_gml/extensions/GDKExtension/gdkextension_windows/GDKExtension/GDKExtension.vcxproj
+++ b/source/GDKExtension_gml/extensions/GDKExtension/gdkextension_windows/GDKExtension/GDKExtension.vcxproj
@@ -223,7 +223,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>json-c-static.lib;libxml2_a.lib;xgameruntime.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>json-c-static.lib;libxml2_a.lib;bcrypt.lib;xgameruntime.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
       <Command>xcopy /Y "$(TargetPath)" $(SolutionDir)..\</Command>

--- a/source/GDKExtension_gml/extensions/GDKExtension/gdkextension_windows/GDKExtension/UserManagement.h
+++ b/source/GDKExtension_gml/extensions/GDKExtension/gdkextension_windows/GDKExtension/UserManagement.h
@@ -27,7 +27,7 @@
 #endif
 
 //#define XBOX_USER	XUserHandle
-#define XBOX_USER_GAMERTAG_MAX_LENGTH	64
+#define XBOX_USER_GAMERTAG_MAX_LENGTH	(XUserGamertagComponentUniqueModernMaxBytes + 1)
 
 struct RefCountedGameSaveProvider
 {


### PR DESCRIPTION
The title mostly speaks for itself.

FYI: If you're going to retarget to GDK >= 24XXXX, add this into the package and run batch scripts:
```bat
call %Utils% itemCopyTo "%GDK_PATH%\Xbox.LibHttpClient\Redist\CommonConfiguration\neutral\libHttpClient.GDK.dll" "libHttpClient.GDK.dll"
```
This is a new redistributable DLL that must be copied as well...

FYI 2: The vcxproj file statically mentions a specific runtime version in the VC++ Directories, which is suboptimal especially when 2023 isn't really the runtime you're supposed to use nowadays, perhaps copy YYStd headers into the project and upgrade as needed?