### PR TITLE
Properly export xboxone_sprite_add_from_gamerpicture for this extension

### DIFF
--- a/source/GDKExtension_gml/extensions/GDKExtension/GDKExtension.yy
+++ b/source/GDKExtension_gml/extensions/GDKExtension/GDKExtension.yy
@@ -80,6 +80,7 @@
         {"$GMExtensionFunction":"","%Name":"xboxone_modern_gamertag_for_user","argCount":0,"args":[2,],"documentation":"","externalName":"F_XboxOneModernGamerTagForUser","help":"xboxone_modern_gamertag_for_user(user_id)","hidden":false,"kind":1,"name":"xboxone_modern_gamertag_for_user","resourceType":"GMExtensionFunction","resourceVersion":"2.0","returnType":1,},
         {"$GMExtensionFunction":"","%Name":"xboxone_unique_modern_gamertag_for_user","argCount":0,"args":[2,],"documentation":"","externalName":"F_XboxOneUniqueModernGamerTagForUser","help":"xboxone_unique_modern_gamertag_for_user(user_id)","hidden":false,"kind":1,"name":"xboxone_unique_modern_gamertag_for_user","resourceType":"GMExtensionFunction","resourceVersion":"2.0","returnType":1,},
         {"$GMExtensionFunction":"","%Name":"xboxone_modern_gamertag_suffix_for_user","argCount":0,"args":[2,],"documentation":"","externalName":"F_XboxOneModernGamerTagSuffixForUser","help":"xboxone_modern_gamertag_suffix_for_user(user_id)","hidden":false,"kind":1,"name":"xboxone_modern_gamertag_suffix_for_user","resourceType":"GMExtensionFunction","resourceVersion":"2.0","returnType":1,},
+        {"$GMExtensionFunction":"","%Name":"xboxone_sprite_add_from_gamerpicture","argCount":0,"args":[2,2,2,2,],"documentation":"","externalName":"F_XboxOneSpriteAddFromGamerPicture","help":"xboxone_sprite_add_from_gamerpicture(user,size,xorigin,yorigin)","hidden":false,"kind":1,"name":"xboxone_sprite_add_from_gamerpicture","resourceType":"GMExtensionFunction","resourceVersion":"2.0","returnType":2,},
       ],"init":"","kind":1,"name":"","order":[
         {"name":"gdk_init","path":"extensions/GDKExtension/GDKExtension.yy",},
         {"name":"gdk_update","path":"extensions/GDKExtension/GDKExtension.yy",},
@@ -141,6 +142,7 @@
         {"name":"xboxone_get_token_and_signature","path":"extensions/GDKExtension/GDKExtension.yy",},
         {"name":"xboxone_gamertag_for_user","path":"extensions/GDKExtension/GDKExtension.yy",},
         {"name":"xboxone_update_recent_players","path":"extensions/GDKExtension/GDKExtension.yy",},
+        {"name":"xboxone_sprite_add_from_gamerpicture","path":"extensions/GDKExtension/GDKExtension.yy",},
       ],"origname":"","ProxyFiles":[],"resourceType":"GMExtensionFile","resourceVersion":"2.0","uncompress":false,"usesRunnerInterface":true,},
   ],
   "gradleinject":"\r\n\r\n",
@@ -196,4 +198,5 @@
   "tvosProps":false,
   "tvosSystemFrameworkEntries":[],
   "tvosThirdPartyFrameworkEntries":[],
+
 }

--- a/source/GDKExtension_gml/extensions/GDKExtension/gdkextension_windows/GDKExtension/YoYo_FunctionsM.cpp
+++ b/source/GDKExtension_gml/extensions/GDKExtension/gdkextension_windows/GDKExtension/YoYo_FunctionsM.cpp
@@ -80,7 +80,7 @@ void F_XboxOneReputationForUser(RValue& Result, CInstance* selfinst, CInstance* 
 void F_XboxOneUserForPad(RValue& Result, CInstance* selfinst, CInstance* otherinst, int argc, RValue* arg);
 void F_XboxOnePadCountForUser(RValue& Result, CInstance* selfinst, CInstance* otherinst, int argc, RValue* arg);
 void F_XboxOneSponsorForUser(RValue& Result, CInstance* selfinst, CInstance* otherinst, int argc, RValue* arg);
-void F_XboxOneSpriteAddFromGamerPicture(RValue& Result, CInstance* selfinst, CInstance* otherinst, int argc, RValue* arg);
+YYEXPORT void F_XboxOneSpriteAddFromGamerPicture(RValue& Result, CInstance* selfinst, CInstance* otherinst, int argc, RValue* arg);
 void F_XboxOneShowProfileCardForUser(RValue& Result, CInstance* selfinst, CInstance* otherinst, int argc, RValue* arg);
 
 void F_XboxOneGenerateSessionId(RValue& Result, CInstance* selfinst, CInstance* otherinst, int argc, RValue* arg);
@@ -1090,9 +1090,12 @@ void F_XboxOneUserIsSignedIn(RValue& Result, CInstance* selfinst, CInstance* oth
 		DebugConsoleOutput("xboxone_user_is_signed_in() - user not found\n");
 	}
 }
-/*
+
+YYEXPORT
 void F_XboxOneSpriteAddFromGamerPicture(RValue& Result, CInstance* selfinst, CInstance* otherinst, int argc, RValue* arg)
 {
+	if (!g_gdk_initialised) YYError("xboxone_sprite_add_from_gamerpicture :: GDK Extension was not initialized!");
+
 	Result.kind = VALUE_REAL;
 	Result.val = -1;	
 
@@ -1180,7 +1183,7 @@ void F_XboxOneSpriteAddFromGamerPicture(RValue& Result, CInstance* selfinst, CIn
 				}
 
 				// Use standard HTTP get
-				HTTP_Get(pic_uri.c_str(), ARG_SPRITE, g_pYYRunnerInterface->ASYNCFunc_SpriteAdd, g_pYYRunnerInterface->ASYNCFunc_SpriteCleanup, ctx->pAS);
+				HTTP_Get(pic_uri.c_str(), g_pYYRunnerInterface->ASYNCFunc_SpriteAdd, g_pYYRunnerInterface->ASYNCFunc_SpriteCleanup, ctx->pAS);
 			}
 			else {
 				DebugConsoleOutput("xboxone_sprite_add_from_gamerpicture() - XblProfileGetUserProfileAsync failed (HRESULT 0x%08X)\n", (unsigned)(hr));
@@ -1207,7 +1210,7 @@ void F_XboxOneSpriteAddFromGamerPicture(RValue& Result, CInstance* selfinst, CIn
 
 	Result.val = sprite_idx;
 }
-*/
+
 static bool g_XboxProfileCardLaunching = false;
 
 void F_XboxOneShowProfileCardForUser(RValue& Result, CInstance* selfinst, CInstance* otherinst, int argc, RValue* arg)


### PR DESCRIPTION
Fixes issue #99 
Docs and usage are identical to those for the Xbox function, because it *is* the exact same function.